### PR TITLE
Fix codex `bin`

### DIFF
--- a/bucket/codex-rust.json
+++ b/bucket/codex-rust.json
@@ -12,7 +12,9 @@
             "hash": "13dad71c4f17df1904adcae55c9dec38ff1d4579dab6f865a936592abfb08055"
         }
     },
-    "bin": "codex.exe",
+    "bin": [
+        ["codex-x86_64-pc-windows-msvc.exe", "codex"]
+    ],
     "checkver": {
         "github": "https://github.com/openai/codex",
         "regex": "rust-v([\\d.]+)"


### PR DESCRIPTION
Fixes the failing installation and makes it available as just `codex`.